### PR TITLE
add disableMessageFromOriginEvent constructor parameter

### DIFF
--- a/scripts/config.ts.example
+++ b/scripts/config.ts.example
@@ -6,6 +6,8 @@ export const maxDataSize = 117964
 
 export const isUsingFeeToken = false;
 
+export const disableMessageFromOriginEvent = false;
+
 export const config = {
   rollupConfig: {
     confirmPeriodBlocks: ethers.BigNumber.from('45818'),

--- a/scripts/deployment.ts
+++ b/scripts/deployment.ts
@@ -1,7 +1,7 @@
 import { ethers } from 'hardhat'
 import '@nomiclabs/hardhat-ethers'
 import { deployAllContracts, _isRunningOnArbitrum } from './deploymentUtils'
-import { maxDataSize } from './config'
+import { maxDataSize, disableMessageFromOriginEvent } from './config'
 
 import { ArbSys__factory } from '../build/types'
 
@@ -26,10 +26,12 @@ async function main() {
 
   try {
     // Deploying all contracts
+    const verify = false;
     const contracts = await deployAllContracts(
       signer,
       ethers.BigNumber.from(maxDataSize),
-      true
+      disableMessageFromOriginEvent,
+      verify
     )
 
     // Call setTemplates with the deployed contract addresses

--- a/scripts/deploymentUtils.ts
+++ b/scripts/deploymentUtils.ts
@@ -117,6 +117,7 @@ export async function deployUpgradeExecutor(signer: any): Promise<Contract> {
 export async function deployAllContracts(
   signer: any,
   maxDataSize: BigNumber,
+  disableMessageFromOriginEvent: boolean,
   verify: boolean = true
 ): Promise<Record<string, Contract>> {
   const isOnArb = await _isRunningOnArbitrum(signer)
@@ -139,7 +140,7 @@ export async function deployAllContracts(
     verify
   )
 
-  const ethInbox = await deployContract('Inbox', signer, [maxDataSize], verify)
+  const ethInbox = await deployContract('Inbox', signer, [maxDataSize, disableMessageFromOriginEvent], verify)
   const ethRollupEventInbox = await deployContract(
     'RollupEventInbox',
     signer,
@@ -164,7 +165,7 @@ export async function deployAllContracts(
   const erc20Inbox = await deployContract(
     'ERC20Inbox',
     signer,
-    [maxDataSize],
+    [maxDataSize, disableMessageFromOriginEvent],
     verify
   )
   const erc20RollupEventInbox = await deployContract(

--- a/scripts/local-deployment/deployCreatorAndCreateRollup.ts
+++ b/scripts/local-deployment/deployCreatorAndCreateRollup.ts
@@ -36,6 +36,11 @@ async function main() {
       ? ethers.BigNumber.from(process.env.MAX_DATA_SIZE)
       : ethers.BigNumber.from(117964)
 
+  const disableMessageFromOriginEvent =
+    process.env.DISABLE_MESSAGE_FROM_ORIGIN_EVENT !== undefined
+      ? process.env.DISABLE_MESSAGE_FROM_ORIGIN_EVENT === 'true'
+      : false
+
   /// get fee token address, if undefined use address(0) to have ETH as fee token
   let feeToken = process.env.FEE_TOKEN_ADDRESS as string
   if (!feeToken) {
@@ -62,7 +67,8 @@ async function main() {
 
   /// deploy templates and rollup creator
   console.log('Deploy RollupCreator')
-  const contracts = await deployAllContracts(deployerWallet, maxDataSize, false)
+  const verify = false;
+  const contracts = await deployAllContracts(deployerWallet, maxDataSize, disableMessageFromOriginEvent, verify)
 
   console.log('Set templates on the Rollup Creator')
   await (

--- a/src/bridge/ERC20Inbox.sol
+++ b/src/bridge/ERC20Inbox.sol
@@ -27,8 +27,9 @@ contract ERC20Inbox is AbsInbox, IERC20Inbox {
     using SafeERC20 for IERC20;
 
     constructor(
-        uint256 _maxDataSize
-    ) AbsInbox(_maxDataSize) {}
+        uint256 _maxDataSize,
+        bool _disableMessageFromOriginEvent
+    ) AbsInbox(_maxDataSize, _disableMessageFromOriginEvent) {}
 
     /// @inheritdoc IInboxBase
     function initialize(

--- a/src/bridge/Inbox.sol
+++ b/src/bridge/Inbox.sol
@@ -28,8 +28,9 @@ import "@openzeppelin/contracts-upgradeable/utils/AddressUpgradeable.sol";
  */
 contract Inbox is AbsInbox, IInbox {
     constructor(
-        uint256 _maxDataSize
-    ) AbsInbox(_maxDataSize) {}
+        uint256 _maxDataSize,
+        bool _disableMessageFromOriginEvent
+    ) AbsInbox(_maxDataSize, _disableMessageFromOriginEvent) {}
 
     /// @inheritdoc IInboxBase
     function initialize(

--- a/test/Rollup.t.sol
+++ b/test/Rollup.t.sol
@@ -47,6 +47,7 @@ contract RollupTest is Test {
     uint256 constant MINI_STAKE_VALUE = 2;
     uint64 constant CONFIRM_PERIOD_BLOCKS = 100;
     uint256 constant MAX_DATA_SIZE = 117964;
+    bool constant DISABLE_MESSAGE_FROM_ORIGIN_EVENT = false;
     uint64 constant CHALLENGE_GRACE_PERIOD_BLOCKS = 10;
 
     bytes32 constant FIRST_ASSERTION_BLOCKHASH = keccak256("FIRST_ASSERTION_BLOCKHASH");
@@ -94,7 +95,7 @@ contract RollupTest is Test {
         bridge: new Bridge(),
         sequencerInbox: new SequencerInbox(MAX_DATA_SIZE, dummyReader4844, false, false),
         delayBufferableSequencerInbox: new SequencerInbox(MAX_DATA_SIZE, dummyReader4844, false, true),
-        inbox: new Inbox(MAX_DATA_SIZE),
+        inbox: new Inbox(MAX_DATA_SIZE, DISABLE_MESSAGE_FROM_ORIGIN_EVENT),
         rollupEventInbox: new RollupEventInbox(),
         outbox: new Outbox()
     });
@@ -102,7 +103,7 @@ contract RollupTest is Test {
         bridge: new ERC20Bridge(),
         sequencerInbox: new SequencerInbox(MAX_DATA_SIZE, dummyReader4844, true, false),
         delayBufferableSequencerInbox: new SequencerInbox(MAX_DATA_SIZE, dummyReader4844, true, true),
-        inbox: new ERC20Inbox(MAX_DATA_SIZE),
+        inbox: new ERC20Inbox(MAX_DATA_SIZE, DISABLE_MESSAGE_FROM_ORIGIN_EVENT),
         rollupEventInbox: new ERC20RollupEventInbox(),
         outbox: new ERC20Outbox()
     });

--- a/test/contract/sequencerInboxForceInclude.spec.ts
+++ b/test/contract/sequencerInboxForceInclude.spec.ts
@@ -16,10 +16,13 @@
 
 /* eslint-env node, mocha */
 
-import { ethers, network } from 'hardhat'
+import { Interface } from '@ethersproject/abi'
 import { BigNumber } from '@ethersproject/bignumber'
+import { Event } from '@ethersproject/contracts'
 import { Block, TransactionReceipt } from '@ethersproject/providers'
 import { expect } from 'chai'
+import { constants, Signer } from 'ethers'
+import { ethers, network } from 'hardhat'
 import {
   Bridge,
   Bridge__factory,
@@ -31,17 +34,14 @@ import {
   SequencerInbox__factory,
   TransparentUpgradeableProxy__factory,
 } from '../../build/types'
-import { applyAlias, initializeAccounts } from './utils'
-import { Event } from '@ethersproject/contracts'
-import { Interface } from '@ethersproject/abi'
 import {
   BridgeInterface,
   MessageDeliveredEvent,
 } from '../../build/types/src/bridge/Bridge'
-import { constants, Signer } from 'ethers'
-import { Toolkit4844 } from './toolkit4844'
 import { data } from './batchData.json'
 import { seqInterface } from './testHelpers'
+import { Toolkit4844 } from './toolkit4844'
+import { applyAlias, initializeAccounts } from './utils'
 
 const mineBlocks = async (count: number, timeDiffPerBlock = 14) => {
   const block = (await network.provider.send('eth_getBlockByNumber', [
@@ -219,7 +219,11 @@ describe('SequencerInboxForceInclude', async () => {
     }
   }
 
-  const setupSequencerInbox = async (maxDelayBlocks = 10, maxDelayTime = 0) => {
+  const setupSequencerInbox = async (
+    maxDelayBlocks = 10,
+    maxDelayTime = 0,
+    disableMessageFromOriginEvent = false
+  ) => {
     const accounts = await initializeAccounts()
     const admin = accounts[0]
     const adminAddr = await admin.getAddress()
@@ -247,7 +251,10 @@ describe('SequencerInboxForceInclude', async () => {
     const inboxFac = (await ethers.getContractFactory(
       'Inbox'
     )) as Inbox__factory
-    const inboxTemplate = await inboxFac.deploy(117964)
+    const inboxTemplate = await inboxFac.deploy(
+      117964,
+      disableMessageFromOriginEvent
+    )
     const bridgeFac = (await ethers.getContractFactory(
       'Bridge'
     )) as Bridge__factory

--- a/test/contract/testHelpers.ts
+++ b/test/contract/testHelpers.ts
@@ -295,7 +295,8 @@ export const setupSequencerInbox = async (
   isDelayBufferable = false,
   isBlobMock = false,
   maxDelay: MaxTimeVariation = maxDelayDefault,
-  delayConfig: DelayConfig = delayConfigDefault
+  delayConfig: DelayConfig = delayConfigDefault,
+  disableMessageFromOriginEvent = false
 ) => {
   const accounts = await initializeAccounts()
   const admin = accounts[0]
@@ -320,7 +321,10 @@ export const setupSequencerInbox = async (
     isDelayBufferable
   )
   const inboxFac = (await ethers.getContractFactory('Inbox')) as Inbox__factory
-  const inboxTemplate = await inboxFac.deploy(117964)
+  const inboxTemplate = await inboxFac.deploy(
+    117964,
+    disableMessageFromOriginEvent
+  )
   const bridgeFac = (await ethers.getContractFactory(
     'Bridge'
   )) as Bridge__factory

--- a/test/foundry/AbsInbox.t.sol
+++ b/test/foundry/AbsInbox.t.sol
@@ -16,6 +16,7 @@ abstract contract AbsInboxTest is Test {
     IBridge public bridge;
 
     uint256 public constant MAX_DATA_SIZE = 117_964;
+    bool public constant DISABLE_MESSAGE_FROM_ORIGIN_EVENT = false;
 
     address public user = address(100);
     address public rollup = address(1000);
@@ -168,7 +169,7 @@ abstract contract AbsInboxTest is Test {
     }
 
     function test_initialize_revert_NonDelegated() public {
-        ERC20Inbox inb = new ERC20Inbox(MAX_DATA_SIZE);
+        ERC20Inbox inb = new ERC20Inbox(MAX_DATA_SIZE, DISABLE_MESSAGE_FROM_ORIGIN_EVENT);
         vm.expectRevert("Function must be called through delegatecall");
         inb.initialize(bridge, ISequencerInbox(seqInbox));
     }

--- a/test/foundry/BridgeCreator.t.sol
+++ b/test/foundry/BridgeCreator.t.sol
@@ -13,13 +13,14 @@ contract BridgeCreatorTest is Test {
     BridgeCreator public creator;
     address public owner = address(100);
     uint256 public constant MAX_DATA_SIZE = 117_964;
+    bool public constant DISABLE_MESSAGE_FROM_ORIGIN_EVENT = false;
     IReader4844 dummyReader4844 = IReader4844(address(137));
 
     BridgeCreator.BridgeTemplates ethBasedTemplates = BridgeCreator.BridgeTemplates({
         bridge: new Bridge(),
         sequencerInbox: new SequencerInbox(MAX_DATA_SIZE, dummyReader4844, false, false),
         delayBufferableSequencerInbox: new SequencerInbox(MAX_DATA_SIZE, dummyReader4844, false, true),
-        inbox: new Inbox(MAX_DATA_SIZE),
+        inbox: new Inbox(MAX_DATA_SIZE, DISABLE_MESSAGE_FROM_ORIGIN_EVENT),
         rollupEventInbox: new RollupEventInbox(),
         outbox: new Outbox()
     });
@@ -27,7 +28,7 @@ contract BridgeCreatorTest is Test {
         bridge: new ERC20Bridge(),
         sequencerInbox: new SequencerInbox(MAX_DATA_SIZE, dummyReader4844, true, false),
         delayBufferableSequencerInbox: new SequencerInbox(MAX_DATA_SIZE, dummyReader4844, true, true),
-        inbox: new ERC20Inbox(MAX_DATA_SIZE),
+        inbox: new ERC20Inbox(MAX_DATA_SIZE, DISABLE_MESSAGE_FROM_ORIGIN_EVENT),
         rollupEventInbox: new ERC20RollupEventInbox(),
         outbox: new ERC20Outbox()
     });

--- a/test/foundry/ERC20Bridge.t.sol
+++ b/test/foundry/ERC20Bridge.t.sol
@@ -18,6 +18,7 @@ contract ERC20BridgeTest is AbsBridgeTest {
     IERC20 public nativeToken;
 
     uint256 public constant MAX_DATA_SIZE = 117_964;
+    bool public constant DISABLE_MESSAGE_FROM_ORIGIN_EVENT = false;
 
     // msg details
     uint8 public kind = 7;
@@ -34,7 +35,7 @@ contract ERC20BridgeTest is AbsBridgeTest {
         erc20Bridge.initialize(IOwnable(rollup), address(nativeToken));
 
         // deploy inbox
-        inbox = address(TestUtil.deployProxy(address(new ERC20Inbox(MAX_DATA_SIZE))));
+        inbox = address(TestUtil.deployProxy(address(new ERC20Inbox(MAX_DATA_SIZE, DISABLE_MESSAGE_FROM_ORIGIN_EVENT))));
         IERC20Inbox(address(inbox)).initialize(bridge, ISequencerInbox(seqInbox));
     }
 

--- a/test/foundry/ERC20Inbox.t.sol
+++ b/test/foundry/ERC20Inbox.t.sol
@@ -21,7 +21,7 @@ contract ERC20InboxTest is AbsInboxTest {
         // deploy token, bridge and inbox
         nativeToken = new ERC20PresetMinterPauser("Appchain Token", "App");
         bridge = IBridge(TestUtil.deployProxy(address(new ERC20Bridge())));
-        inbox = IInboxBase(TestUtil.deployProxy(address(new ERC20Inbox(MAX_DATA_SIZE))));
+        inbox = IInboxBase(TestUtil.deployProxy(address(new ERC20Inbox(MAX_DATA_SIZE,DISABLE_MESSAGE_FROM_ORIGIN_EVENT))));
         erc20Inbox = IERC20Inbox(address(inbox));
 
         // init bridge and inbox
@@ -89,7 +89,7 @@ contract ERC20InboxTest is AbsInboxTest {
 
         IERC20Bridge _bridge = IERC20Bridge(TestUtil.deployProxy(address(new ERC20Bridge())));
         IERC20Inbox _inbox =
-            IERC20Inbox(TestUtil.deployProxy(address(new ERC20Inbox(MAX_DATA_SIZE))));
+            IERC20Inbox(TestUtil.deployProxy(address(new ERC20Inbox(MAX_DATA_SIZE,DISABLE_MESSAGE_FROM_ORIGIN_EVENT))));
 
         // init bridge and inbox
         address _rollup = makeAddr("_rollup");
@@ -146,7 +146,7 @@ contract ERC20InboxTest is AbsInboxTest {
 
         IERC20Bridge _bridge = IERC20Bridge(TestUtil.deployProxy(address(new ERC20Bridge())));
         IERC20Inbox _inbox =
-            IERC20Inbox(TestUtil.deployProxy(address(new ERC20Inbox(MAX_DATA_SIZE))));
+            IERC20Inbox(TestUtil.deployProxy(address(new ERC20Inbox(MAX_DATA_SIZE,DISABLE_MESSAGE_FROM_ORIGIN_EVENT))));
 
         // init bridge and inbox
         address _rollup = makeAddr("_rollup");
@@ -202,7 +202,7 @@ contract ERC20InboxTest is AbsInboxTest {
 
         IERC20Bridge _bridge = IERC20Bridge(TestUtil.deployProxy(address(new ERC20Bridge())));
         IERC20Inbox _inbox =
-            IERC20Inbox(TestUtil.deployProxy(address(new ERC20Inbox(MAX_DATA_SIZE))));
+            IERC20Inbox(TestUtil.deployProxy(address(new ERC20Inbox(MAX_DATA_SIZE,DISABLE_MESSAGE_FROM_ORIGIN_EVENT))));
 
         // init bridge and inbox
         address _rollup = makeAddr("_rollup");
@@ -333,7 +333,7 @@ contract ERC20InboxTest is AbsInboxTest {
 
         IERC20Bridge _bridge = IERC20Bridge(TestUtil.deployProxy(address(new ERC20Bridge())));
         IERC20Inbox _inbox =
-            IERC20Inbox(TestUtil.deployProxy(address(new ERC20Inbox(MAX_DATA_SIZE))));
+            IERC20Inbox(TestUtil.deployProxy(address(new ERC20Inbox(MAX_DATA_SIZE,DISABLE_MESSAGE_FROM_ORIGIN_EVENT))));
 
         // init bridge and inbox
         address _rollup = makeAddr("_rollup");
@@ -449,7 +449,7 @@ contract ERC20InboxTest is AbsInboxTest {
 
         IERC20Bridge _bridge = IERC20Bridge(TestUtil.deployProxy(address(new ERC20Bridge())));
         IERC20Inbox _inbox =
-            IERC20Inbox(TestUtil.deployProxy(address(new ERC20Inbox(MAX_DATA_SIZE))));
+            IERC20Inbox(TestUtil.deployProxy(address(new ERC20Inbox(MAX_DATA_SIZE,DISABLE_MESSAGE_FROM_ORIGIN_EVENT))));
 
         // init bridge and inbox
         address _rollup = makeAddr("_rollup");
@@ -538,7 +538,7 @@ contract ERC20InboxTest is AbsInboxTest {
 
         IERC20Bridge _bridge = IERC20Bridge(TestUtil.deployProxy(address(new ERC20Bridge())));
         IERC20Inbox _inbox =
-            IERC20Inbox(TestUtil.deployProxy(address(new ERC20Inbox(MAX_DATA_SIZE))));
+            IERC20Inbox(TestUtil.deployProxy(address(new ERC20Inbox(MAX_DATA_SIZE,DISABLE_MESSAGE_FROM_ORIGIN_EVENT))));
 
         // init bridge and inbox
         address _rollup = makeAddr("_rollup");
@@ -626,7 +626,7 @@ contract ERC20InboxTest is AbsInboxTest {
 
         IERC20Bridge _bridge = IERC20Bridge(TestUtil.deployProxy(address(new ERC20Bridge())));
         IERC20Inbox _inbox =
-            IERC20Inbox(TestUtil.deployProxy(address(new ERC20Inbox(MAX_DATA_SIZE))));
+            IERC20Inbox(TestUtil.deployProxy(address(new ERC20Inbox(MAX_DATA_SIZE,DISABLE_MESSAGE_FROM_ORIGIN_EVENT))));
 
         // init bridge and inbox
         address _rollup = makeAddr("_rollup");
@@ -822,7 +822,7 @@ contract ERC20InboxTest is AbsInboxTest {
 
         IERC20Bridge _bridge = IERC20Bridge(TestUtil.deployProxy(address(new ERC20Bridge())));
         IERC20Inbox _inbox =
-            IERC20Inbox(TestUtil.deployProxy(address(new ERC20Inbox(MAX_DATA_SIZE))));
+            IERC20Inbox(TestUtil.deployProxy(address(new ERC20Inbox(MAX_DATA_SIZE,DISABLE_MESSAGE_FROM_ORIGIN_EVENT))));
 
         // init bridge and inbox
         address _rollup = makeAddr("_rollup");
@@ -872,7 +872,7 @@ contract ERC20InboxTest is AbsInboxTest {
 
         IERC20Bridge _bridge = IERC20Bridge(TestUtil.deployProxy(address(new ERC20Bridge())));
         IERC20Inbox _inbox =
-            IERC20Inbox(TestUtil.deployProxy(address(new ERC20Inbox(MAX_DATA_SIZE))));
+            IERC20Inbox(TestUtil.deployProxy(address(new ERC20Inbox(MAX_DATA_SIZE,DISABLE_MESSAGE_FROM_ORIGIN_EVENT))));
 
         // init bridge and inbox
         address _rollup = makeAddr("_rollup");
@@ -1200,7 +1200,7 @@ contract ERC20InboxTest is AbsInboxTest {
 
         IERC20Bridge _bridge = IERC20Bridge(TestUtil.deployProxy(address(new ERC20Bridge())));
         IERC20Inbox _inbox =
-            IERC20Inbox(TestUtil.deployProxy(address(new ERC20Inbox(MAX_DATA_SIZE))));
+            IERC20Inbox(TestUtil.deployProxy(address(new ERC20Inbox(MAX_DATA_SIZE,DISABLE_MESSAGE_FROM_ORIGIN_EVENT))));
 
         // init bridge and inbox
         address _rollup = makeAddr("_rollup");
@@ -1251,7 +1251,7 @@ contract ERC20InboxTest is AbsInboxTest {
 
         IERC20Bridge _bridge = IERC20Bridge(TestUtil.deployProxy(address(new ERC20Bridge())));
         IERC20Inbox _inbox =
-            IERC20Inbox(TestUtil.deployProxy(address(new ERC20Inbox(MAX_DATA_SIZE))));
+            IERC20Inbox(TestUtil.deployProxy(address(new ERC20Inbox(MAX_DATA_SIZE,DISABLE_MESSAGE_FROM_ORIGIN_EVENT))));
 
         // init bridge and inbox
         address _rollup = makeAddr("_rollup");
@@ -1302,7 +1302,7 @@ contract ERC20InboxTest is AbsInboxTest {
 
         IERC20Bridge _bridge = IERC20Bridge(TestUtil.deployProxy(address(new ERC20Bridge())));
         IERC20Inbox _inbox =
-            IERC20Inbox(TestUtil.deployProxy(address(new ERC20Inbox(MAX_DATA_SIZE))));
+            IERC20Inbox(TestUtil.deployProxy(address(new ERC20Inbox(MAX_DATA_SIZE,DISABLE_MESSAGE_FROM_ORIGIN_EVENT))));
 
         // init bridge and inbox
         address _rollup = makeAddr("_rollup");
@@ -1351,7 +1351,7 @@ contract ERC20InboxTest is AbsInboxTest {
 
         IERC20Bridge _bridge = IERC20Bridge(TestUtil.deployProxy(address(new ERC20Bridge())));
         IERC20Inbox _inbox =
-            IERC20Inbox(TestUtil.deployProxy(address(new ERC20Inbox(MAX_DATA_SIZE))));
+            IERC20Inbox(TestUtil.deployProxy(address(new ERC20Inbox(MAX_DATA_SIZE,DISABLE_MESSAGE_FROM_ORIGIN_EVENT))));
 
         // init bridge and inbox
         address _rollup = makeAddr("_rollup");

--- a/test/foundry/ERC20Outbox.t.sol
+++ b/test/foundry/ERC20Outbox.t.sol
@@ -14,6 +14,7 @@ contract ERC20OutboxTest is AbsOutboxTest {
     IERC20 public nativeToken;
 
     uint256 public constant MAX_DATA_SIZE = 117_964;
+    bool public constant DISABLE_MESSAGE_FROM_ORIGIN_EVENT = false;
 
     function setUp() public {
         // deploy token, bridge and outbox
@@ -112,7 +113,7 @@ contract ERC20OutboxTest is AbsOutboxTest {
 
         IERC20Bridge _bridge = IERC20Bridge(TestUtil.deployProxy(address(new ERC20Bridge())));
         IERC20Inbox _inbox =
-            IERC20Inbox(TestUtil.deployProxy(address(new ERC20Inbox(MAX_DATA_SIZE))));
+            IERC20Inbox(TestUtil.deployProxy(address(new ERC20Inbox(MAX_DATA_SIZE,DISABLE_MESSAGE_FROM_ORIGIN_EVENT))));
         ERC20Outbox _outbox = ERC20Outbox(TestUtil.deployProxy(address(new ERC20Outbox())));
 
         // init bridge and inbox
@@ -218,7 +219,7 @@ contract ERC20OutboxTest is AbsOutboxTest {
 
         IERC20Bridge _bridge = IERC20Bridge(TestUtil.deployProxy(address(new ERC20Bridge())));
         IERC20Inbox _inbox =
-            IERC20Inbox(TestUtil.deployProxy(address(new ERC20Inbox(MAX_DATA_SIZE))));
+            IERC20Inbox(TestUtil.deployProxy(address(new ERC20Inbox(MAX_DATA_SIZE,DISABLE_MESSAGE_FROM_ORIGIN_EVENT))));
         ERC20Outbox _outbox = ERC20Outbox(TestUtil.deployProxy(address(new ERC20Outbox())));
 
         // init bridge and inbox
@@ -323,7 +324,7 @@ contract ERC20OutboxTest is AbsOutboxTest {
 
         IERC20Bridge _bridge = IERC20Bridge(TestUtil.deployProxy(address(new ERC20Bridge())));
         IERC20Inbox _inbox =
-            IERC20Inbox(TestUtil.deployProxy(address(new ERC20Inbox(MAX_DATA_SIZE))));
+            IERC20Inbox(TestUtil.deployProxy(address(new ERC20Inbox(MAX_DATA_SIZE,DISABLE_MESSAGE_FROM_ORIGIN_EVENT))));
         ERC20Outbox _outbox = ERC20Outbox(TestUtil.deployProxy(address(new ERC20Outbox())));
 
         // init bridge and inbox

--- a/test/foundry/Inbox.t.sol
+++ b/test/foundry/Inbox.t.sol
@@ -16,7 +16,7 @@ contract InboxTest is AbsInboxTest {
     function setUp() public {
         // deploy token, bridge and inbox
         bridge = IBridge(TestUtil.deployProxy(address(new Bridge())));
-        inbox = IInboxBase(TestUtil.deployProxy(address(new Inbox(MAX_DATA_SIZE))));
+        inbox = IInboxBase(TestUtil.deployProxy(address(new Inbox(MAX_DATA_SIZE, DISABLE_MESSAGE_FROM_ORIGIN_EVENT))));
         ethInbox = IInbox(address(inbox));
 
         // init bridge and inbox

--- a/test/foundry/RollupCreator.t.sol
+++ b/test/foundry/RollupCreator.t.sol
@@ -34,12 +34,13 @@ contract RollupCreatorTest is Test {
     // 1 gwei
     uint256 public constant MAX_FEE_PER_GAS = 1_000_000_000;
     uint256 public constant MAX_DATA_SIZE = 117_964;
+    bool public constant DISABLE_MESSAGE_FROM_ORIGIN_EVENT = false;
 
     BridgeCreator.BridgeTemplates public ethBasedTemplates = BridgeCreator.BridgeTemplates({
         bridge: new Bridge(),
         sequencerInbox: new SequencerInbox(MAX_DATA_SIZE, dummyReader4844, false, false),
         delayBufferableSequencerInbox: new SequencerInbox(MAX_DATA_SIZE, dummyReader4844, false, true),
-        inbox: new Inbox(MAX_DATA_SIZE),
+        inbox: new Inbox(MAX_DATA_SIZE, DISABLE_MESSAGE_FROM_ORIGIN_EVENT),
         rollupEventInbox: new RollupEventInbox(),
         outbox: new Outbox()
     });
@@ -47,7 +48,7 @@ contract RollupCreatorTest is Test {
         bridge: new ERC20Bridge(),
         sequencerInbox: new SequencerInbox(MAX_DATA_SIZE, dummyReader4844, true, false),
         delayBufferableSequencerInbox: new SequencerInbox(MAX_DATA_SIZE, dummyReader4844, true, true),
-        inbox: new ERC20Inbox(MAX_DATA_SIZE),
+        inbox: new ERC20Inbox(MAX_DATA_SIZE, DISABLE_MESSAGE_FROM_ORIGIN_EVENT),
         rollupEventInbox: new ERC20RollupEventInbox(),
         outbox: new ERC20Outbox()
     });

--- a/test/stakingPool/AssertionStakingPool.t.sol
+++ b/test/stakingPool/AssertionStakingPool.t.sol
@@ -98,7 +98,7 @@ contract AssertionPoolTest is Test {
         bridge: new Bridge(),
         sequencerInbox: new SequencerInbox(MAX_DATA_SIZE, dummyReader4844, false, false),
         delayBufferableSequencerInbox: new SequencerInbox(MAX_DATA_SIZE, dummyReader4844, false, true),
-        inbox: new Inbox(MAX_DATA_SIZE),
+        inbox: new Inbox(MAX_DATA_SIZEE, DISABLE_MESSAGE_FROM_ORIGIN_EVENT,
         rollupEventInbox: new RollupEventInbox(),
         outbox: new Outbox()
     });
@@ -106,7 +106,7 @@ contract AssertionPoolTest is Test {
         bridge: new ERC20Bridge(),
         sequencerInbox: new SequencerInbox(MAX_DATA_SIZE, dummyReader4844, true, false),
         delayBufferableSequencerInbox: new SequencerInbox(MAX_DATA_SIZE, dummyReader4844, true, false),
-        inbox: new ERC20Inbox(MAX_DATA_SIZE),
+        inbox: new ERC20Inbox(MAX_DATA_SIZEE, DISABLE_MESSAGE_FROM_ORIGIN_EVENT,
         rollupEventInbox: new ERC20RollupEventInbox(),
         outbox: new ERC20Outbox()
     });


### PR DESCRIPTION
adds `disableMessageFromOriginEvent` which allows a deployment to opt-out of the `InboxMessageDeliveredFromOrigin` event calldata optimization